### PR TITLE
Emit an error event in addition to logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ ipc.on('update-available', function () {
 })
 ```
 
+# Error handling
+By default errors are logged to both the console and a file. The default log file location is obtained by getting the [AppDirectory.userData()](https://www.npmjs.com/package/appdirectory) folder: `{userData}/logs/updater.log`. Additionally you can replace the default logger or simply handle errors manually with the below optional API's:
+
+```
+updater.on('error', function (err) {
+  // todo: manually handle errors here in addition to default logger behavior...
+});
+
+// The logger signature is essentially the same as the console.
+var customLogger = {
+  log: console.log,
+  error: console.error,
+  info: console.info,
+  warn: console.warn,
+  debug: console.debug
+};
+updater.start(customLogger);
+```
+
 # Publishing Updates
 There are two kinds of updates you can publish:
  * The Application itself

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -186,7 +186,11 @@ function start(appDir, logger, callback) {
 	})
 	logger.log('Starting...')
 	context.load(appDir, function (err, ctx) {
-		if(err) return callback(err)
+		if(err) {
+			logger.error(err);
+			that.emit('error', err);
+			return callback(err);
+		}
 		if(logger === Logger.default && ctx.name && ctx.publisher) {
 			logger = new Logger(directory.appDir(ctx.publisher, ctx.name), null, true)
 		}
@@ -198,7 +202,11 @@ function start(appDir, logger, callback) {
 			// If there is a pending update, do a full update instead of starting the app.
 			// This is set when a dependency update is available.
 			fullUpdate(ctx.publisher, ctx.name, logger, function (err) {
-				if(err) return callback(err);
+				if(err) {
+					logger.error(err);
+					that.emit('error', err);
+					return callback(err);
+				}
 				that.emit('updateRequired');
 				callback();
 			})
@@ -208,10 +216,17 @@ function start(appDir, logger, callback) {
 			process.exit(0);
 		} else {
 			isValid(appDir, logger, function (err, valid) {
-				if(err) return callback(err);
+				if(err) {
+					logger.error(err);
+					that.emit('error', err);
+					return callback(err);
+				}
 				if(valid) {
 					var notifier = notify(appDir, logger);
-					notifier.on('error', logger.error.bind(logger));
+					notifier.on('error', function (err) {
+						logger.error(err);
+						that.emit('error', err);
+					});
 					notifier.on('updateAvailable', function (result) {
 						if(result && (result.app || result.dependencies.length)) {
 							// If a new version of the app is available or
@@ -220,15 +235,23 @@ function start(appDir, logger, callback) {
 							var appData = directory.appDir(ctx.publisher, ctx.name)
 							var pendingUpdatePath = path.join(appData, '.update')
 							file.touch(pendingUpdatePath, 'PENDING', function (err) {
-								if(err) return callback(err)
-								that.emit('updateAvailable')
+								if(err) {
+									logger.error(err);
+									that.emit('error', err);
+								} else {
+									that.emit('updateAvailable')
+								}
 							})
 						} else if (result && result.plugins.length) {
 							// If only plugin updates are available we can go ahead and update those
 							// right now and then notify the user that they can restart to apply them.
 							updater.update(result, null, logger, function (err) {
-								if(err) return callback(err)
-								that.emit('updateAvailable')
+								if(err) {
+									logger.error(err);
+									that.emit('error', err);
+								} else {
+									that.emit('updateAvailable');
+								}
 							})
 						}
 
@@ -242,7 +265,11 @@ function start(appDir, logger, callback) {
 
 				} else {
 					fullUpdate(ctx.publisher, ctx.name, logger, function (err) {
-						if(err) return callback(err);
+						if(err) {
+							logger.error(err);
+							that.emit('error', err);
+							return callback(err);
+						}
 						that.emit('updateRequired');
 						callback();
 					})


### PR DESCRIPTION
This fix adds an error event to the updater which can be called by the start function.

Additionally errors are now logged and emitted properly. Also callback is only called when appropriate.

A user may want to handle certain kinds of errors manually, such as
providing a UI for entering proxy information before restarting or
showing a custom error reporting UI.