### PR TITLE
Instead of exiting automatically, fire an event.

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -204,8 +204,8 @@ function start(appDir, logger, callback) {
 			})
 		} else if(ctx.updateInProgress) {
 			// This can happen if the user tries to re-launch the app while an update is
-			// currently in progress. In that case just close and wait.
-			process.exit(0);
+			// currently in progress. The user should close the app in this case.
+			that.emit('updateInProgress');
 		} else {
 			isValid(appDir, logger, function (err, valid) {
 				if(err) return callback(err);


### PR DESCRIPTION
- [x] @jaunkst 

Related to #34.

This will allow the user to do any cleanup desired in case the app is in a bad state.