### PR TITLE
feat: add url encoding for slash char in application names

### DIFF
--- a/lib/check.js
+++ b/lib/check.js
@@ -69,6 +69,7 @@ function checkDependency(name, callback) {
 }
 
 function checkPlugin(name, callback) {
+  name = name.replace("/", "%2f")
   var appName = this.name
   var appVersion = this.version
   var registry = this.registry

--- a/lib/context.js
+++ b/lib/context.js
@@ -44,6 +44,7 @@ function load(appDir, callback) {
       file.readJson(packagePath, function (err, package) {
         if (err) return callback(err)
         var name = package.name
+        name = name.replace("/", "%2f")
         var version = package.version
         var publisher = package.publisher || name
         var defaultChannel = package.defaultChannel || 'latest'

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "url": "https://github.com/evolvelabs/electron-updater/issues"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "watch": "mocha --watch"
   },
   "bin": {
     "electron-updater": "./bin/cli",


### PR DESCRIPTION
Started using this tool for a project that requires scoped packages, noticed that it started failing because of the slash in the package names.  After looking into solutions it seems the npm standard requires the slashes to be url-encoded before being passed to the server.

Some examples of what the actual npm tool does to solve this:
  - NPM View - https://github.com/npm/npm/blob/master/lib/view.js#L101
  - mapToRegistry method - https://github.com/npm/npm/blob/master/lib/utils/map-to-registry.js#L16

All tests are passing, tested with a local sinopia server, on both 0.3.0 and this new branch.

Thought it would be easier to start this pull request as this project is strictly under a maintenance-only mode, also would've added new tests, but it seemed like it would take a lot of time with the current mocks & stubs setup.

In the future if this project keeps going (which I hope it does, it's very useful! :), it may be beneficial to use one of npm's utility methods etc. to form the remote registry url.