### PR TITLE
fix(scope): fix scoped package directories from using "%2f" instead of "/"

### DIFF
--- a/lib/check.js
+++ b/lib/check.js
@@ -8,6 +8,7 @@ var semver = require('semver'),
 
 
 function satisfy(registry, name, desired, current, exists, callback) {
+  name = name.replace("/", "%2f");
   var url = registry + '/' + name
   got(url, {json:true}, function (err, data) {
     if(err) return callback(err)
@@ -36,9 +37,12 @@ function satisfy(registry, name, desired, current, exists, callback) {
 function checkApp(context, callback) {
   var registry = context.registry
   var name = context.name
+  name = name.replace("/", "%2f")
+
   var channel = context.channel
   var current = context.version
   var url = registry + '/' + name
+
   got(url, {json:true}, function(err, data) {
     if(err) return callback(err)
     var distTags = data['dist-tags']
@@ -69,7 +73,6 @@ function checkDependency(name, callback) {
 }
 
 function checkPlugin(name, callback) {
-  name = name.replace("/", "%2f")
   var appName = this.name
   var appVersion = this.version
   var registry = this.registry

--- a/lib/context.js
+++ b/lib/context.js
@@ -44,7 +44,6 @@ function load(appDir, callback) {
       file.readJson(packagePath, function (err, package) {
         if (err) return callback(err)
         var name = package.name
-        name = name.replace("/", "%2f")
         var version = package.version
         var publisher = package.publisher || name
         var defaultChannel = package.defaultChannel || 'latest'

--- a/lib/update.js
+++ b/lib/update.js
@@ -67,6 +67,7 @@ function getElectron(electronDir, context, logger, callback) {
 }
 
 function getSubDependencyVersion(name, desired, context, callback) {
+  name = name.replace("/", "%2f");
 	var url = context.registry + '/' + name
 	got(url, {json:true}, function (err, data) {
 		if(err) return callback({
@@ -122,6 +123,7 @@ function updatePlugin(name, version, context, logger, callback) {
 	var appData = directory.appDir(context.publisher, context.name)
 	var pluginsDir = path.join(appData, 'plugins')
 	var dir = path.join(pluginsDir, name, version)
+  name = name.replace("/", "%2f");
 	var url = context.registry + '/' + name + '/' + version
 	logger.log('Updating plugin: ' + name + '@' + version + '...')
 	got(url, {json: true}, function (err, data) {
@@ -140,6 +142,7 @@ function updatePlugin(name, version, context, logger, callback) {
 }
 
 function updateDependency(dir, name, version, context, logger, callback) {
+  name = name.replace("/", "%2f");
 	logger.log('Updating dependency: ' + name + '@' + version)
 	var dir = path.resolve(path.join(dir, 'node_modules', name))
 	var url = context.registry + '/' + name + '/' + version
@@ -162,6 +165,7 @@ function updateDependency(dir, name, version, context, logger, callback) {
 }
 
 function updateApp(dir, name, version, electronDir, context, logger, callback) {
+  name = name.replace("/", "%2f");
 	var url = context.registry + '/' + name + '/' + version
 	got(url, {json:true}, function (err, data) {
 		if(err) return callback(err)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-updater",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Cross platform auto-updater for electron applications",
   "main": "index.js",
   "author": "Evolve LLC",


### PR DESCRIPTION
Sorry for another update, but we found that the directory was being encoded unnecessarily with "%2f" causing the updater to fail, so this is a quick fix replacing only the names instead of directories which were correct before.